### PR TITLE
Add option to control taxonomies navigation on homepage

### DIFF
--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,5 @@
+[on_this_page]
+other = "목차"
+
+[reading_time]
+other = "읽는 데에 {{ .Count }}분"

--- a/layouts/partials/hb/modules/blog/index.html
+++ b/layouts/partials/hb/modules/blog/index.html
@@ -15,7 +15,9 @@
     </div>
   {{- end }}
 </div>
-{{ partialCached "hb/modules/blog/home/taxonomies" . }}
+{{- if default true site.Params.hb.blog.home.taxonomies }}
+  {{ partialCached "hb/modules/blog/home/taxonomies" . }}
+{{- end }}
 {{- with .Paginator }}
   {{ partial "hb/modules/blog/posts" (dict "Pages" .Pages "Cols" "row-cols-1 row-cols-md-2 row-cols-lg-3") }}
   {{ partial "hb/modules/pagination/index" . }}


### PR DESCRIPTION
User can hide taxonomies navigator in homepage 

params.yaml
hb:
  blog:
    home:
      taxonomies: false # default: true