### PR TITLE
Show '…' after summary when it is truncated

### DIFF
--- a/assets/hb/modules/blog/scss/post/_summary.scss
+++ b/assets/hb/modules/blog/scss/post/_summary.scss
@@ -9,3 +9,8 @@
         margin-bottom: 0;
     }
 }
+.summary-truncated {
+    &::after {
+        content: "…";
+    }
+}

--- a/layouts/partials/hb/modules/blog/post/card.html
+++ b/layouts/partials/hb/modules/blog/post/card.html
@@ -1,5 +1,5 @@
 {{- $page := .Page }}
-{{- $summary := default true .Summary }}
+{{- $showSummary := default true .Summary }}
 {{- $readingTime := default true .ReadingTime }}
 {{- $meta := default true .Meta }}
 <div class="hb-blog-post-card card border-0 overflow-hidden">
@@ -30,16 +30,16 @@
         {{ partialCached "hb/modules/blog/post/meta/taxonomies" $page $page }}
       </div>
     {{- end }}
-    {{- if $summary }}
-      {{- if $page.Truncated }}
-        <div class="hb-blog-post-summary summary-truncated card-text text-secondary">
-          {{- default $page.Summary $page.Description -}}
-        </div>
-      {{- else -}}
-        <div class="hb-blog-post-summary card-text text-secondary">
-          {{- default $page.Summary $page.Description -}}
-        </div>
+    {{- if $showSummary }}
+      {{- $summary := $page.Summary }}
+      {{- $truncated := $page.Truncated }}
+      {{- with $page.Description }}
+        {{- $summary = . }}
+        {{- $truncated = false }}
       {{- end }}
+      <div class="hb-blog-post-summary card-text text-secondary{{ cond $truncated ` summary-truncated` `` }}">
+        {{- $summary -}}
+      </div>
     {{- end }}
   </div>
 </div>

--- a/layouts/partials/hb/modules/blog/post/card.html
+++ b/layouts/partials/hb/modules/blog/post/card.html
@@ -31,9 +31,15 @@
       </div>
     {{- end }}
     {{- if $summary }}
-      <div class="hb-blog-post-summary card-text text-secondary">
-        {{- default $page.Summary $page.Description -}}
-      </div>
+      {{- if $page.Truncated }}
+        <div class="hb-blog-post-summary summary-truncated card-text text-secondary">
+          {{- default $page.Summary $page.Description -}}
+        </div>
+      {{- else -}}
+        <div class="hb-blog-post-summary card-text text-secondary">
+          {{- default $page.Summary $page.Description -}}
+        </div>
+      {{- end }}
     {{- end }}
   </div>
 </div>


### PR DESCRIPTION
This will show `…` after summary text if it is truncated.

![before](https://github.com/hbstack/blog/assets/37061801/9bcd77cb-5e39-4e2a-b2da-2ac8acfba56c)

I think I should provide option for site owner what character to display instead of `…`, but I can't decide what config name it should have. I don't know if I can use Hugo's variable/param in SCSS style neither.

If we can use Hugo variable in SCSS, the config would be put under `params.hb.blog.`, but `summary-truncation-indicator` doesn't seem to be _nice_ or _intuitive_ word for describing this.

Currently, it should be overridden by custom style in `index.scss` like this:
```scss
.summary-truncated::after { content: "$"; } /* $ is random character */
```
If we can't use Hugo's param, telling people about modifying `index.scss` like that would be required.

---

<details>
<summary>Not that related to this PR, but <code>hasCJKLanguage</code> is broken in Hugo.</summary>

I think we should suggest people not to set `hasCJKLanguage` to `true` even though their site is written with CJK language.  
I found this problem while making my customization (and PR).

They claim `hasCJKLanguage` as

> This will make `.Summary` and `.WordCount` behave correctly for CJK languages.

but it doesn't.

`.Summary` returned less words than `70` words/characters which is default value of `summaryLength`.  
Turning it off returned much longer, consist length of summary text.

It also didn't processed some characters.  
I found that there is weird `&` character at the end of summary text. According to content of that post, it should be `"` instead. I think `"` was initially `&quot;`, but was truncated, only lefting `&`.

This is bug of Hugo, not HB Framework. But I think it would be worthy to tell people using HB Framework that `hasCJKLanguage` will cause unexpected behavior, contrary to what Hugo Official Documentation says.

At least, with that suggestion, they won't experience same problem that I had.

</details>