### PR TITLE
Fix 'Read More' button link

### DIFF
--- a/layouts/partials/hb/modules/blog/post/card.html
+++ b/layouts/partials/hb/modules/blog/post/card.html
@@ -44,7 +44,7 @@
       {{- if and $readMore $truncated }}
         <div class="mt-2">
           <a
-            class="btn btn-sm btn-outline-secondary" href="{{ .RelPermalink }}">
+            class="btn btn-sm btn-outline-secondary" href="{{ .Page.RelPermalink }}">
             {{- "read_more" | i18n -}}
           </a>
         </div>


### PR DESCRIPTION
This will fix 'Read More' button's mis-configured link. It was pointing section page, instead of post page.

Tested with my local installation.
