### PR TITLE
feat(i18n): update PT-BR translation file

### DIFF
--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -5,4 +5,5 @@ other = "Nesta página"
 other = "Leia mais"
 
 [reading_time]
-other = "{{ .Count }} minuto(s) de leitura"
+one = "{{ .Count }} minuto de leitura"
+other = "{{ .Count }} minutos de leitura"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -5,4 +5,4 @@ other = "Nesta página"
 other = "Leia mais"
 
 [reading_time]
-other = "{{ .Count }} minutos de leitura"
+other = "{{ .Count }} minuto(s) de leitura"


### PR DESCRIPTION
Change to `minuto(s)` to match singular and plural forms:

- 1 minuto
- 3 minutos