### PR TITLE
fix: correct the default thumbnail in the case of baseURL contains subpaths

### DIFF
--- a/layouts/partials/hb/modules/blog/post/card-img.html
+++ b/layouts/partials/hb/modules/blog/post/card-img.html
@@ -7,13 +7,14 @@
     {{- $img = index . 0 }}
   {{- else }}
     {{- $res := partialCached "hb/functions/page-thumbnail" . . }}
-    {{- $default := site.Params.hb.blog.post_thumbnail_default }}
-    {{/* Get the default thumbnail if set. */}}
-    {{- if and (not $res) $default }}
-      {{- $res = resources.Get $default }}
-    {{- end }}
-    {{- with $res }}
-      {{- $img = replace .RelPermalink $page.RelPermalink "" | printf "%s?height=360px" }}
+    {{- if $res }}
+      {{- $img = replace $res.Permalink $page.Permalink "" | printf "%s?height=360" }}
+    {{- else }}
+      {{/* Get the default thumbnail if set. */}}
+      {{- $default := site.Params.hb.blog.post_thumbnail_default }}
+      {{- with resources.Get $default }}
+        {{- $img = strings.TrimPrefix "/" $default | printf "/%s?height=360" }}
+      {{- end }}
     {{- end }}
   {{- end -}}
   {{- with $img }}


### PR DESCRIPTION
Closes hbstack/site#712