### PR TITLE
feat: add the external_url page parameter

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -46,3 +46,6 @@ sticky = true
 
 [params.hb.blog.toc]
 position = "end" # start, end or content.
+
+[params.hugopress.modules.hb-blog.hooks.head-begin]
+cacheable = false

--- a/layouts/partials/hb/modules/blog/post/card.html
+++ b/layouts/partials/hb/modules/blog/post/card.html
@@ -1,4 +1,10 @@
 {{- $page := .Page }}
+{{- $url := $page.RelPermalink }}
+{{- $external := false }}
+{{- with $page.Params.external_url }}
+  {{- $url = . }}
+  {{- $external = true }}
+{{- end }}
 {{- $showSummary := default true .Summary }}
 {{- $readMore := default true .ReadMore }}
 {{- $readingTime := default true .ReadingTime }}
@@ -24,11 +30,15 @@
       <a
         class="hb-blog-post-title-link d-block"
         title="{{ $page.Title }}"
-        href="{{ $page.RelPermalink }}">
+        {{ if $external }}target="_blank" rel="external"{{ end }}
+        href="{{ $url }}">
         {{- if $page.Params.pinned }}
           {{- partialCached "hb/modules/blog/helpers/pinned-icon" . -}}
         {{- end }}
         {{- $page.Title -}}
+        {{- if $external }}
+          {{- partial "icons/icon" (dict "vendor" "bootstrap" "name" "box-arrow-up-right" "className" "ms-1") }}
+        {{- end }}
       </a>
     </div>
     {{- if $meta }}
@@ -49,7 +59,7 @@
       {{- if and $readMore $truncated }}
         <div class="mt-2">
           <a
-            class="text-secondary" href="{{ $page.RelPermalink }}">
+            class="text-secondary" href="{{ $url }}"{{ if $external }}target="_blank" rel="external"{{ end }}>
             {{- i18n "read_more_about" $page.Title -}}
           </a>
         </div>

--- a/layouts/partials/hugopress/modules/hb-blog/hooks/head-begin.html
+++ b/layouts/partials/hugopress/modules/hb-blog/hooks/head-begin.html
@@ -1,0 +1,3 @@
+{{- with .Page.Params.external_url }}
+  <meta http-equiv="refresh" content="0; url={{ . }}">
+{{- end }}


### PR DESCRIPTION
Closes #760.

This feature allow showing external posts on your site, and navigate to the corresponding URL on click.

```
---
title: ...
description: ...
external_url: https://example.org/foo
---
```

