### PR TITLE
feat: add the post-authors module

### DIFF
--- a/modules/post-authors/assets/hb/modules/blog-post-authors/scss/index.scss
+++ b/modules/post-authors/assets/hb/modules/blog-post-authors/scss/index.scss
@@ -1,0 +1,18 @@
+.hb-blog-post-author {
+  .hb-blog-author-img {
+    width: 100px;
+    height: 100px;
+  }
+
+  .hb-term-socials {
+    justify-content: start !important;
+    left: -.25rem;
+    display: flex;
+    position: relative;
+    margin-top: .25rem;
+
+    .nav-item {
+      margin: .25rem !important;
+    }
+  }
+}

--- a/modules/post-authors/go.mod
+++ b/modules/post-authors/go.mod
@@ -1,0 +1,5 @@
+module github.com/hbstack/blog/modules/post-authors
+
+go 1.19
+
+require github.com/hbstack/blog v0.29.1 // indirect

--- a/modules/post-authors/go.sum
+++ b/modules/post-authors/go.sum
@@ -1,0 +1,2 @@
+github.com/hbstack/blog v0.29.1 h1:G38wrWsjbjpLY7GEqTidohrFWYImxLtyRI2bUwRFr2Q=
+github.com/hbstack/blog v0.29.1/go.mod h1:seD+hskGzqejUgQJeif45jFXJDP9ltY7UkWBvb0Q/To=

--- a/modules/post-authors/hugo.toml
+++ b/modules/post-authors/hugo.toml
@@ -1,0 +1,9 @@
+[[module.imports]]
+path = "github.com/hbstack/blog"
+
+[params.hugopress.modules.hb-blog-post-authors.hooks.hb-blog-post-content-begin]
+
+[params.hugopress.modules.hb-blog-post-authors.hooks.hb-blog-post-content-end]
+
+[params.hb.blog.post_authors]
+position = "top"

--- a/modules/post-authors/layouts/partials/hb/modules/blog-post-authors/index.html
+++ b/modules/post-authors/layouts/partials/hb/modules/blog-post-authors/index.html
@@ -1,0 +1,39 @@
+{{- with .GetTerms "authors" }}
+  <div class="hb-blog-post-authors hb-module">
+    {{- $title := "Authors" }}
+    {{- with site.GetPage "/authors" }}
+      {{- $title = .Title }}
+    {{- end }}
+    <div class="h5 mb-3">
+      {{- partial "icons/icon" (dict "vendor" "bs" "name" "pencil-square" "className" "me-1") -}}
+      {{- $title -}}
+    </div>
+    {{- $terms := . }}
+    {{- range $i, $term := $terms }}
+      {{- $last := eq (len $terms) (add $i 1) }}
+      <div
+        class="hb-blog-post-author my-3 border-top pt-3"
+        href="{{ .RelPermalink }}">
+        <div class="d-flex">
+          {{ partial "hb/modules/blog/author/image" (dict
+            "Page" .
+            "ClassName" "hb-blog-author-img rounded-circle me-3")
+          }}
+          <div class="d-flex flex-column justify-content-center">
+            <p class="h6 mb-0 d-flex">
+              <a class="text-decoration-none" href="{{ .RelPermalink }}">
+                {{- .Title -}}
+              </a>
+            </p>
+            {{ with .Description }}
+              <small class="text-body-secondary mt-2">{{ . }}</small>
+            {{ end }}
+            {{- with .Params.socials }}
+              {{ partial "hb/modules/blog/term/socials" . }}
+            {{- end }}
+          </div>
+        </div>
+      </div>
+    {{- end }}
+  </div>
+{{- end }}

--- a/modules/post-authors/layouts/partials/hugopress/modules/hb-blog-post-authors/hooks/hb-blog-post-content-begin.html
+++ b/modules/post-authors/layouts/partials/hugopress/modules/hb-blog-post-authors/hooks/hb-blog-post-content-begin.html
@@ -1,0 +1,3 @@
+{{- if eq (default "top" site.Params.hb.blog.post_authors.position) "top" }}
+  {{ partial "hb/modules/blog-post-authors/index" .Page }}
+{{- end }}

--- a/modules/post-authors/layouts/partials/hugopress/modules/hb-blog-post-authors/hooks/hb-blog-post-content-end.html
+++ b/modules/post-authors/layouts/partials/hugopress/modules/hb-blog-post-authors/hooks/hb-blog-post-content-end.html
@@ -1,0 +1,3 @@
+{{- if eq (default "top" site.Params.hb.blog.post_authors.position) "bottom" }}
+  {{ partial "hb/modules/blog-post-authors/index" .Page }}
+{{- end }}


### PR DESCRIPTION
Fixes #790 

This module displaying the post's authors on the `top` or `bottom` of content.

```yaml
// params.yaml
hb:
  blog:
    post_authors:
      position: top # or bottom.
```

![image](https://github.com/hbstack/blog/assets/17720932/35121fcf-e0ea-4677-8205-b0f56e6ee3b4)
