### PR TITLE
feat: add the `hb.blog.post_thumbnail_height` parameter, which repres…

### DIFF
--- a/assets/hb/modules/blog/scss/post/_card.scss
+++ b/assets/hb/modules/blog/scss/post/_card.scss
@@ -1,5 +1,5 @@
 .hb-blog-post-card-img {
-    height: 160px;
+    height: $hb-blog-post-thumbnail-height;
     object-fit: cover;
     width: 100%;
     transition: 0.3s;
@@ -11,7 +11,7 @@
 
 .hb-blog-post-card-img-none {
     background: rgba(var(--#{$prefix}body-color-rgb), 0.1);
-    height: 160px;
+    height: $hb-blog-post-thumbnail-height;
     filter: blur(1px);
     font-size: 1.5rem;
     text-transform: uppercase;

--- a/assets/hb/modules/blog/scss/variables.tmpl.scss
+++ b/assets/hb/modules/blog/scss/variables.tmpl.scss
@@ -7,3 +7,6 @@ $hb-blog-home-pinned-posts-pos: '{{ default "" site.Params.hb.blog.home.pinned_p
 
 // ToC
 $hb-blog-toc-position: {{ default "end" site.Params.hb.blog.toc.position }};
+
+// Thumbnail
+$hb-blog-post-thumbnail-height: {{ default "160px" site.Params.hb.blog.post_thumbnail_height }};

--- a/hugo.toml
+++ b/hugo.toml
@@ -27,9 +27,11 @@ full_width = false
 paginate = 12
 post_date_format = ':date_long'
 post_thumbnail = true
+post_thumbnail_height = "160px"
 post_thumbnail_placeholder = ""
 post_thumbnail_default = "images/thumbnail.png"
 post_thumbnail_position = "top"
+post_thumbnail_resize_height = 360
 list_cols_md = 2
 list_cols_lg = 3 # won't work when sidebar was enabled.
 

--- a/layouts/partials/hb/modules/blog/post/card-img.html
+++ b/layouts/partials/hb/modules/blog/post/card-img.html
@@ -14,13 +14,14 @@
     {{- $img = index . 0 }}
   {{- else }}
     {{- $res := partialCached "hb/functions/page-thumbnail" . . }}
+    {{- $thumbnailHeight := default 360 site.Params.hb.blog.post_thumbnail_resize_height }}
     {{- if $res }}
-      {{- $img = replace $res.Permalink $page.Permalink "" | printf "%s?height=360" }}
+      {{- $img = printf "%s?height=%d" (replace $res.Permalink $page.Permalink "") $thumbnailHeight }}
     {{- else }}
       {{/* Get the default thumbnail if set. */}}
       {{- $default := site.Params.hb.blog.post_thumbnail_default }}
       {{- with resources.Get $default }}
-        {{- $img = strings.TrimPrefix "/" $default | printf "/%s?height=360" }}
+        {{- $img = printf "/%s?height=%d" (strings.TrimPrefix "/" $default) $thumbnailHeight }}
       {{- end }}
     {{- end }}
   {{- end -}}


### PR DESCRIPTION
…ents the height of thumbnail, default to `160px`

feat: add the `hb.blog.post_thumbnail_resize_height` parameter for changing the height for resizing thumbnails, default to `360`.

Fixes #802 

```yaml
// params.yaml
hb:
  blog:
    post_thumbnail_height: 160px
    post_thumbnail_resize_height: 360
```