### PR TITLE
feat: add the hb.blog.post_read_more parameter

### DIFF
--- a/layouts/partials/hb/modules/blog/posts.html
+++ b/layouts/partials/hb/modules/blog/posts.html
@@ -1,5 +1,5 @@
 {{- $cols := default "row-cols-1 row-cols-lg-2 row-cols-xl-3" .Cols }}
-{{- $readMore := default true .ReadMore }}
+{{- $readMore := default (default true site.Params.hb.blog.post_read_more) .ReadMore }}
 {{- $modularize := default true .Modularize }}
 <div class="hb-blog-posts row {{ $cols }} g-3 mb-3">
   {{ range .Pages }}


### PR DESCRIPTION
Closes #818 

To hide the read more button, you'll need to set `hb.blog.post_read_more` as `false`.