### PR TITLE
fix params path for terms.profile_metrics

### DIFF
--- a/layouts/partials/hb/modules/blog/term/profile.html
+++ b/layouts/partials/hb/modules/blog/term/profile.html
@@ -14,7 +14,7 @@
   {{- with .Params.socials }}
     {{ partial "hb/modules/blog/term/socials" . }}
   {{- end }}
-  {{- if default true site.Params.terms.profile_metrics }}
+  {{- if default true site.Params.hb.terms.profile_metrics }}
     {{ partialCached "hb/modules/blog/term/metrics" . . }}
   {{- end }}
 </div>


### PR DESCRIPTION
Hi,

currently `layouts/partials/hb/modules/blog/term/profile.html` checks for `site.Params.terms.profile_metrics` to determine if the metrics should be shown.

According to the [documentation](https://hbstack.dev/modules/blog/overview/) it should be configured via `site.Params.hb.terms.profile_metrics` therefore this small PR to fix the behavior.


Best,
Andrwe