### PR TITLE
i18n: add Arabic translations

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,0 +1,22 @@
+[metrics_page_sections]
+other = "الأقسام"
+
+[metrics_page_types]
+other = "الأنواع"
+
+[metrics_posts]
+other = "التدوينات"
+
+[on_this_page]
+other = "في هذه الصفحة"
+
+[read_more_about]
+other = "اقرأ المزيد عن {{ . }}."
+
+[reading_time]
+zero = "أقل من دقيقة للقراءة"
+one = "دقيقة واحدة للقراءة"
+two = "دقيقتان للقراءة"
+few = "{{ .Count }} دقائق للقراءة"
+many = "{{ .Count }} دقيقة للقراءة"
+other = "{{ .Count }} دقيقة للقراءة"


### PR DESCRIPTION
## Summary

- add Arabic translations for blog metrics, the table of contents, and read-more labels
- add all Arabic CLDR plural forms for reading time

## Why

Arabic sites currently fall back to English for these labels.

## Validation

- `npm run lint:prettier`
- rendered every new key and reading-time plural form with Hugo 0.146.5
- built with `--printI18nWarnings`; no warnings for the added keys

The full lint command still reports three pre-existing SCSS stylelint failures on the upstream branch.
